### PR TITLE
Add an explicit non-generative test for characters that are multi-byte in all UTF encodings

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,3 +13,6 @@ spec = describe "unidecode" $ do
 
   it "doesn't crash" $ property $
     \x ->  unidecode x == unidecode x
+
+  it "strips out non-ASCII text" $ do
+    concatMap unidecode "五十音順" `shouldBe` "" 


### PR DESCRIPTION
Just an extra test to discern the lib behavior.